### PR TITLE
Use fixed cassandra read timeout

### DIFF
--- a/clearwater_cassandra/cassandra_plugin.py
+++ b/clearwater_cassandra/cassandra_plugin.py
@@ -132,21 +132,9 @@ class CassandraPlugin(SynchroniserPluginBase):
         doc["seed_provider"][0]["parameters"][0]["seeds"] = seeds_list_str
         doc["endpoint_snitch"] = "GossipingPropertyFileSnitch"
 
-        # Work out the timeout from the target_latency_us value (assuming
-        # 100000 if it isn't set)
-        get_latency_cmd = "target_latency_us=100000; . /etc/clearwater/config; echo -n $target_latency_us"
-        latency = subprocess.check_output(get_latency_cmd,
-                                          shell=True,
-                                          stderr=subprocess.STDOUT)
-
-        try:
-            # We want the timeout value to be 4/5ths the maximum acceptable time
-            # of a HTTP request (which is 5 * target latency)
-            timeout = (int(latency) / 1000) * 4
-        except ValueError:  #  pragma: no cover
-            timeout = 400
-
-        doc["read_request_timeout_in_ms"] = timeout
+        # The read request timeout must not be higher than the Thrift connection
+        # timeout, which is currently set to 250ms
+        doc["read_request_timeout_in_ms"] = 230
 
         # Commit logs.  We want to cap these, as the default of 8GB is sufficient
         # to exhaust the root filesystem on a low-spec (20GB) node, but we should


### PR DESCRIPTION
It must not be greater that the Thrift timeout, which is currently hardcoded to
250ms, so use a read timeout of 230ms for Cassandra.